### PR TITLE
fix jsonPath implementation

### DIFF
--- a/pkg/az/action.go
+++ b/pkg/az/action.go
@@ -47,7 +47,7 @@ func (a Action) GetSteps() []builder.ExecutableStep {
 	// Go doesn't have generics, nothing to see here...
 	steps := make([]builder.ExecutableStep, len(a.Steps))
 	for i := range a.Steps {
-		steps[i] = a.Steps[i]
+		steps[i] = a.Steps[i].TypedCommand
 	}
 
 	return steps
@@ -127,7 +127,7 @@ type TypedCommand interface {
 	builder.SuppressesOutput
 }
 
-var _ TypedCommand = UserCommand{}
+var _ TypedCommand = &UserCommand{}
 
 type UserCommand struct {
 	Name           string        `yaml:"name"`
@@ -145,23 +145,23 @@ func (s UserCommand) GetWorkingDir() string {
 	return ""
 }
 
-var _ builder.ExecutableStep = UserCommand{}
-var _ builder.StepWithOutputs = UserCommand{}
-var _ builder.SuppressesOutput = UserCommand{}
+var _ builder.ExecutableStep = &UserCommand{}
+var _ builder.StepWithOutputs = &UserCommand{}
+var _ builder.SuppressesOutput = &UserCommand{}
 
-func (s UserCommand) GetCommand() string {
+func (s *UserCommand) GetCommand() string {
 	return "az"
 }
 
-func (s UserCommand) GetArguments() []string {
+func (s *UserCommand) GetArguments() []string {
 	return s.Arguments
 }
 
-func (s UserCommand) GetFlags() builder.Flags {
+func (s *UserCommand) GetFlags() builder.Flags {
 	return append(s.Flags, builder.NewFlag("output", "json"))
 }
 
-func (s UserCommand) GetOutputs() []builder.Output {
+func (s *UserCommand) GetOutputs() []builder.Output {
 	// Go doesn't have generics, nothing to see here...
 	outputs := make([]builder.Output, len(s.Outputs))
 	for i := range s.Outputs {
@@ -170,11 +170,11 @@ func (s UserCommand) GetOutputs() []builder.Output {
 	return outputs
 }
 
-func (s UserCommand) SuppressesOutput() bool {
+func (s *UserCommand) SuppressesOutput() bool {
 	return s.SuppressOutput
 }
 
-func (s UserCommand) SetAction(_ string) {}
+func (s *UserCommand) SetAction(_ string) {}
 
 var _ builder.OutputJsonPath = Output{}
 var _ builder.OutputFile = Output{}

--- a/pkg/az/group.go
+++ b/pkg/az/group.go
@@ -14,9 +14,10 @@ var (
 
 // GroupCommand ensures that a group exist or not
 type GroupCommand struct {
-	action   string
-	Name     string `yaml:"name"`
-	Location string `yaml:"location"`
+	action      string
+	Description string `yaml:"description"`
+	Name        string `yaml:"name"`
+	Location    string `yaml:"location"`
 }
 
 func (c *GroupCommand) HandleError(cxt *context.Context, err builder.ExitError, stdout string, stderr string) error {


### PR DESCRIPTION
This PR addresses two issues that causes the outputs not being captured when a jsonPath is defined.
1. The `Steps` being returned from an `Action` is a pointer, therefore when asserting it against `StepWithOutputs` interface, we need the `GetOutputs` method to be implemented as a pointer receiver method.
2. Since `TypedStep` is a concrete type that has `TypedCommand` interface embedded in the struct, the compiler only remembers all the methods declared in the `TypeCommand` for an `TypedStep` instance. The `UserCommand` is a concrete type implementing `TypedCommand` interface, we need to return the concrete implementation so the type assertion against `StepWithOutputs` interface can reach the `GetOutputs` method on the `UserCommand` type

closes https://github.com/getporter/porter/issues/2067