### PR TITLE
only add mixin user agent when it's not in the env var already

### DIFF
--- a/pkg/az/config.go
+++ b/pkg/az/config.go
@@ -31,16 +31,25 @@ func (m *Mixin) SetUserAgent() {
 		return
 	}
 
+	porterUserAgent := pkg.UserAgent()
+	mixinUserAgent := m.GetMixinUserAgent()
+	userAgent := []string{porterUserAgent, mixinUserAgent}
 	// Append porter and the mixin's version to the user agent string. Some clouds and
 	// environments will have set the environment variable already and we don't want
 	// to clobber it.
-	porterUserAgent := pkg.UserAgent()
-	value := []string{porterUserAgent, m.GetMixinUserAgent()}
+	value := strings.Join(userAgent, " ")
 	if agentStr, ok := m.LookupEnv(AzureUserAgentEnvVar); ok {
-		value = append(value, agentStr)
+
+		// Check if we have already set the user agent
+		if strings.Contains(agentStr, value) {
+			value = agentStr
+		} else {
+			userAgent = append(userAgent, agentStr)
+			value = strings.Join(userAgent, " ")
+		}
 	}
 
-	m.userAgent = strings.Join(value, " ")
+	m.userAgent = value
 
 	// Set the az CLI user agent as an environment variable so that when we call the
 	// az CLI, it's automatically passed too.

--- a/pkg/az/config_test.go
+++ b/pkg/az/config_test.go
@@ -37,8 +37,21 @@ func TestMixinSetsUserAgentEnvVar(t *testing.T) {
 		require.Equal(t, expected, m.Getenv(AzureUserAgentEnvVar))
 		require.Equal(t, expected, m.userAgent, "validate we remember the user agent string for later")
 	})
-
+	t.Run("env var already set", func(t *testing.T) {
+		// Validate that calling multiple times doesn't make a messed up env var
+		pkg.Commit = "abc123"
+		pkg.Version = "v1.2.3"
+		cfg := runtime.NewConfig()
+		customUserAgent := "getporter/porter getporter/az/v1.2.3"
+		cfg.Setenv(AzureUserAgentEnvVar, customUserAgent)
+		m := NewFor(cfg)
+		m.SetUserAgent()
+		expected := "getporter/porter getporter/az/v1.2.3"
+		require.Equal(t, expected, m.Getenv(AzureUserAgentEnvVar))
+		require.Equal(t, expected, m.userAgent, "validate we remember the user agent string for later")
+	})
 	t.Run("call multiple times", func(t *testing.T) {
+		os.Unsetenv(AzureUserAgentEnvVar)
 		// Validate that calling multiple times doesn't make a messed up env var
 		pkg.Commit = "abc123"
 		pkg.Version = "v1.2.3"


### PR DESCRIPTION
Currently, the user agent is always set twice if porter already set the user agent env during build. This PR fixes the issue