### PR TITLE
Add `login` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin
 .cnab
 /build/git_askpass.sh
 az
+!pkg/az
+!.gitignore

--- a/README.md
+++ b/README.md
@@ -219,17 +219,36 @@ mixins:
 
 ### Authenticate
 
+The az mixin supports several authentication methods. All are provided with custom `login` command:
+
 ```yaml
-az:
-  description: "Azure CLI login"
-  arguments:
-    - login
-  flags:
-    service-principal:
-    username: ${ bundle.credentials.AZURE_SP_CLIENT_ID }
-    password: ${ bundle.credentials.AZURE_SP_PASSWORD }
-    tenant: ${ bundle.credentials.AZURE_TENANT }
+login:
+  az:
+    login:
 ```
+
+### Existing Azure CLI Authentication
+
+If you have already authenticated using `az login`, the mixin will use your
+existing credentials. This requires the following files to exist in your
+`.azure` directory:
+- `azureProfile.json`: Contains your Azure profile information.
+- `msal_token_cache.json`: Contains the cached authentication tokens.
+
+### Service Principal Authentication
+
+To authenticate using a service principal, set the following environment
+variables:
+- `AZURE_CLIENT_ID`
+- `AZURE_CLIENT_SECRET`
+- `AZURE_TENANT_ID`
+
+### Managed Identity Authentication
+
+When running in Azure, you can authenticate using managed identity. By default,
+the system-assigned managed identity is used. To use a user-assigned managed
+identity, set the `AZURE_CLIENT_ID` environment variable to the client ID of
+the managed identity.
 
 ### Provision a VM
 

--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ mixins:
 The az mixin supports several authentication methods. All are provided with custom `login` command:
 
 ```yaml
-login:
-  az:
-    login:
+install:
+  - az:
+      login:
 ```
 
 ### Existing Azure CLI Authentication

--- a/pkg/az/action.go
+++ b/pkg/az/action.go
@@ -88,6 +88,8 @@ func (s *TypedStep) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			continue
 		case "group":
 			cmd = &GroupCommand{}
+    case "login":
+      cmd = &LoginCommand{}
 		default: // It's a custom user command
 			customCmd := &UserCommand{}
 			b, err := yaml.Marshal(step)

--- a/pkg/az/login.go
+++ b/pkg/az/login.go
@@ -33,11 +33,16 @@ func (c *LoginCommand) SetAction(action string) {
 }
 
 func (c *LoginCommand) GetCommand() string {
+	if c.azureDirExists() {
+		// Use a no-op command since we don't have to log in.
+		return "true"
+	}
+
 	return "az"
 }
 
 func (c *LoginCommand) GetArguments() []string {
-	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".azure")); err == nil {
+	if c.azureDirExists() {
 		return []string{}
 	}
 	return []string{"login"}
@@ -46,7 +51,7 @@ func (c *LoginCommand) GetArguments() []string {
 func (c *LoginCommand) GetFlags() builder.Flags {
 	flags := builder.Flags{}
 
-	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".azure")); err == nil {
+	if c.azureDirExists() {
 		return flags
 	}
 
@@ -70,4 +75,9 @@ func (c *LoginCommand) GetFlags() builder.Flags {
 
 func (c *LoginCommand) SuppressesOutput() bool {
 	return false
+}
+
+func (c *LoginCommand) azureDirExists() bool {
+	_, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".azure"))
+	return err == nil
 }

--- a/pkg/az/login.go
+++ b/pkg/az/login.go
@@ -1,0 +1,72 @@
+package az
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"get.porter.sh/porter/pkg/exec/builder"
+)
+
+var (
+	_ TypedCommand             = &LoginCommand{}
+	_ builder.HasErrorHandling = &LoginCommand{}
+)
+
+// LoginCommand handles logging into Azure
+type LoginCommand struct {
+	action      string
+	Description string `yaml:"description"`
+}
+
+func (c *LoginCommand) HandleError(ctx context.Context, err builder.ExitError, stdout string, stderr string) error {
+	// Handle specific login errors if necessary
+	return err
+}
+
+func (c *LoginCommand) GetWorkingDir() string {
+	return ""
+}
+
+func (c *LoginCommand) SetAction(action string) {
+	c.action = action
+}
+
+func (c *LoginCommand) GetCommand() string {
+	return "az"
+}
+
+func (c *LoginCommand) GetArguments() []string {
+	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".azure")); err == nil {
+		return []string{}
+	}
+	return []string{"login"}
+}
+
+func (c *LoginCommand) GetFlags() builder.Flags {
+	flags := builder.Flags{}
+
+  if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".azure")); err == nil {
+    return flags
+  }
+
+	if os.Getenv("AZURE_CLIENT_ID") != "" && os.Getenv("AZURE_CLIENT_SECRET") != "" && os.Getenv("AZURE_TENANT_ID") != "" {
+		// Add flags for service principal authentication
+		flags = append(flags, builder.NewFlag("username", os.Getenv("AZURE_CLIENT_ID")))
+		flags = append(flags, builder.NewFlag("password", os.Getenv("AZURE_CLIENT_SECRET")))
+		flags = append(flags, builder.NewFlag("tenant", os.Getenv("AZURE_TENANT_ID")))
+	} else if os.Getenv("AZURE_CLIENT_ID") != "" {
+		// Add flag for user-assigned managed identity
+		flags = append(flags, builder.NewFlag("identity", ""))
+		flags = append(flags, builder.NewFlag("username", os.Getenv("AZURE_CLIENT_ID")))
+	} else {
+		// Add flag for system-assigned managed identity
+		flags = append(flags, builder.NewFlag("identity", ""))
+	}
+
+	return flags
+}
+
+func (c *LoginCommand) SuppressesOutput() bool {
+	return false
+}

--- a/pkg/az/login.go
+++ b/pkg/az/login.go
@@ -46,9 +46,9 @@ func (c *LoginCommand) GetArguments() []string {
 func (c *LoginCommand) GetFlags() builder.Flags {
 	flags := builder.Flags{}
 
-  if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".azure")); err == nil {
-    return flags
-  }
+	if _, err := os.Stat(filepath.Join(os.Getenv("HOME"), ".azure")); err == nil {
+		return flags
+	}
 
 	if os.Getenv("AZURE_CLIENT_ID") != "" && os.Getenv("AZURE_CLIENT_SECRET") != "" && os.Getenv("AZURE_TENANT_ID") != "" {
 		// Add flags for service principal authentication

--- a/pkg/az/login.go
+++ b/pkg/az/login.go
@@ -52,6 +52,7 @@ func (c *LoginCommand) GetFlags() builder.Flags {
 
 	if os.Getenv("AZURE_CLIENT_ID") != "" && os.Getenv("AZURE_CLIENT_SECRET") != "" && os.Getenv("AZURE_TENANT_ID") != "" {
 		// Add flags for service principal authentication
+		flags = append(flags, builder.NewFlag("service-principal", ""))
 		flags = append(flags, builder.NewFlag("username", os.Getenv("AZURE_CLIENT_ID")))
 		flags = append(flags, builder.NewFlag("password", os.Getenv("AZURE_CLIENT_SECRET")))
 		flags = append(flags, builder.NewFlag("tenant", os.Getenv("AZURE_TENANT_ID")))

--- a/pkg/az/login_test.go
+++ b/pkg/az/login_test.go
@@ -1,0 +1,119 @@
+package az
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"get.porter.sh/porter/pkg/exec/builder"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoginCommand_GetArguments_ServicePrincipal(t *testing.T) {
+	tempHome := t.TempDir()
+	os.Setenv("HOME", tempHome)
+	os.Setenv("AZURE_CLIENT_ID", "test-client-id")
+	os.Setenv("AZURE_CLIENT_SECRET", "test-client-secret")
+	os.Setenv("AZURE_TENANT_ID", "test-tenant-id")
+	defer os.Unsetenv("AZURE_CLIENT_ID")
+	defer os.Unsetenv("AZURE_CLIENT_SECRET")
+	defer os.Unsetenv("AZURE_TENANT_ID")
+
+	cmd := &LoginCommand{}
+	args := cmd.GetArguments()
+
+	expectedArgs := []string{"login"}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestLoginCommand_GetArguments_ExistingAzureDirectory(t *testing.T) {
+	tempHome := t.TempDir()
+	os.Setenv("HOME", tempHome)
+	homeDir := os.Getenv("HOME")
+	os.MkdirAll(filepath.Join(homeDir, ".azure"), 0755)
+	defer os.RemoveAll(filepath.Join(homeDir, ".azure"))
+
+	cmd := &LoginCommand{}
+	args := cmd.GetArguments()
+
+	expectedArgs := []string{}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestLoginCommand_GetArguments_ManagedIdentity(t *testing.T) {
+	tempHome := t.TempDir()
+	os.Setenv("HOME", tempHome)
+	os.Unsetenv("AZURE_CLIENT_ID")
+	os.Unsetenv("AZURE_CLIENT_SECRET")
+	os.Unsetenv("AZURE_TENANT_ID")
+
+	cmd := &LoginCommand{}
+	args := cmd.GetArguments()
+
+	expectedArgs := []string{"login"}
+	assert.Equal(t, expectedArgs, args)
+}
+
+func TestLoginCommand_GetFlags_ServicePrincipal(t *testing.T) {
+	tempHome := t.TempDir()
+	os.Setenv("HOME", tempHome)
+	os.Setenv("AZURE_CLIENT_ID", "test-client-id")
+	os.Setenv("AZURE_CLIENT_SECRET", "test-client-secret")
+	os.Setenv("AZURE_TENANT_ID", "test-tenant-id")
+	defer os.Unsetenv("AZURE_CLIENT_ID")
+	defer os.Unsetenv("AZURE_CLIENT_SECRET")
+	defer os.Unsetenv("AZURE_TENANT_ID")
+
+	cmd := &LoginCommand{}
+	flags := cmd.GetFlags()
+
+	expectedFlags := builder.Flags{
+		builder.NewFlag("username", "test-client-id"),
+		builder.NewFlag("password", "test-client-secret"),
+		builder.NewFlag("tenant", "test-tenant-id"),
+	}
+	assert.Equal(t, expectedFlags, flags)
+}
+
+func TestLoginCommand_GetFlags_UserAssignedManagedIdentity(t *testing.T) {
+	tempHome := t.TempDir()
+	os.Setenv("HOME", tempHome)
+	os.Setenv("AZURE_CLIENT_ID", "test-client-id")
+	defer os.Unsetenv("AZURE_CLIENT_ID")
+
+	cmd := &LoginCommand{}
+	flags := cmd.GetFlags()
+
+	expectedFlags := builder.Flags{
+		builder.NewFlag("identity", ""),
+		builder.NewFlag("username", "test-client-id"),
+	}
+	assert.Equal(t, expectedFlags, flags)
+}
+
+func TestLoginCommand_GetFlags_SystemManagedIdentity(t *testing.T) {
+	tempHome := t.TempDir()
+	os.Setenv("HOME", tempHome)
+
+	cmd := &LoginCommand{}
+	flags := cmd.GetFlags()
+
+	expectedFlags := builder.Flags{
+		builder.NewFlag("identity", ""),
+	}
+	assert.Equal(t, expectedFlags, flags)
+}
+
+func TestLoginCommand_GetFlags_ExistingAzureDirectory(t *testing.T) {
+  tempHome := t.TempDir()
+  os.Setenv("HOME", tempHome)
+  homeDir := os.Getenv("HOME")
+  os.MkdirAll(filepath.Join(homeDir, ".azure"), 0755)
+  defer os.RemoveAll(filepath.Join(homeDir, ".azure"))
+
+  cmd := &LoginCommand{}
+  flags := cmd.GetFlags()
+
+  expectedFlags := builder.Flags{}
+  assert.Equal(t, expectedFlags, flags)
+}

--- a/pkg/az/login_test.go
+++ b/pkg/az/login_test.go
@@ -30,7 +30,9 @@ func TestLoginCommand_GetCommandAndGetArguments_ExistingAzureDirectory(t *testin
 	tempHome := t.TempDir()
 	os.Setenv("HOME", tempHome)
 	homeDir := os.Getenv("HOME")
-	os.MkdirAll(filepath.Join(homeDir, ".azure"), 0755)
+	if err := os.MkdirAll(filepath.Join(homeDir, ".azure"), 0755); err != nil {
+		t.Fatal("failed to create .azure directory:", err)
+	}
 	defer os.RemoveAll(filepath.Join(homeDir, ".azure"))
 
 	cmd := &LoginCommand{}
@@ -110,7 +112,9 @@ func TestLoginCommand_GetFlags_ExistingAzureDirectory(t *testing.T) {
 	tempHome := t.TempDir()
 	os.Setenv("HOME", tempHome)
 	homeDir := os.Getenv("HOME")
-	os.MkdirAll(filepath.Join(homeDir, ".azure"), 0755)
+	if err := os.MkdirAll(filepath.Join(homeDir, ".azure"), 0755); err != nil {
+		t.Fatal("failed to create .azure directory:", err)
+	}
 	defer os.RemoveAll(filepath.Join(homeDir, ".azure"))
 
 	cmd := &LoginCommand{}

--- a/pkg/az/login_test.go
+++ b/pkg/az/login_test.go
@@ -26,7 +26,7 @@ func TestLoginCommand_GetArguments_ServicePrincipal(t *testing.T) {
 	assert.Equal(t, expectedArgs, args)
 }
 
-func TestLoginCommand_GetArguments_ExistingAzureDirectory(t *testing.T) {
+func TestLoginCommand_GetCommandAndGetArguments_ExistingAzureDirectory(t *testing.T) {
 	tempHome := t.TempDir()
 	os.Setenv("HOME", tempHome)
 	homeDir := os.Getenv("HOME")
@@ -37,6 +37,7 @@ func TestLoginCommand_GetArguments_ExistingAzureDirectory(t *testing.T) {
 	args := cmd.GetArguments()
 
 	expectedArgs := []string{}
+	assert.Equal(t, "true", cmd.GetCommand())
 	assert.Equal(t, expectedArgs, args)
 }
 
@@ -68,6 +69,7 @@ func TestLoginCommand_GetFlags_ServicePrincipal(t *testing.T) {
 	flags := cmd.GetFlags()
 
 	expectedFlags := builder.Flags{
+		builder.NewFlag("service-principal", ""),
 		builder.NewFlag("username", "test-client-id"),
 		builder.NewFlag("password", "test-client-secret"),
 		builder.NewFlag("tenant", "test-tenant-id"),
@@ -105,15 +107,15 @@ func TestLoginCommand_GetFlags_SystemManagedIdentity(t *testing.T) {
 }
 
 func TestLoginCommand_GetFlags_ExistingAzureDirectory(t *testing.T) {
-  tempHome := t.TempDir()
-  os.Setenv("HOME", tempHome)
-  homeDir := os.Getenv("HOME")
-  os.MkdirAll(filepath.Join(homeDir, ".azure"), 0755)
-  defer os.RemoveAll(filepath.Join(homeDir, ".azure"))
+	tempHome := t.TempDir()
+	os.Setenv("HOME", tempHome)
+	homeDir := os.Getenv("HOME")
+	os.MkdirAll(filepath.Join(homeDir, ".azure"), 0755)
+	defer os.RemoveAll(filepath.Join(homeDir, ".azure"))
 
-  cmd := &LoginCommand{}
-  flags := cmd.GetFlags()
+	cmd := &LoginCommand{}
+	flags := cmd.GetFlags()
 
-  expectedFlags := builder.Flags{}
-  assert.Equal(t, expectedFlags, flags)
+	expectedFlags := builder.Flags{}
+	assert.Equal(t, expectedFlags, flags)
 }

--- a/pkg/az/schema/schema.json
+++ b/pkg/az/schema/schema.json
@@ -31,7 +31,7 @@
               }
             },
             "installBicep": {
-              "description": "Indicates if Bicep should be install",
+              "description": "Indicates if Bicep should be installed",
               "type": "boolean"
             }
           },
@@ -174,7 +174,8 @@
           },
           "additionalProperties": false
         },
-        "group": {"$ref": "#/definitions/group"}
+        "group": {"$ref": "#/definitions/group"},
+        "login": {"$ref": "#/definitions/login"}
       },
       "additionalProperties": false
     },
@@ -191,6 +192,11 @@
           "type": "string"
         }
       },
+      "additionalProperties": false
+    },
+    "login": {
+      "description": "Login to Azure",
+      "type": "object",
       "additionalProperties": false
     }
   },


### PR DESCRIPTION
Closes #33.

1. Check for the existence of `~/.azure`, which signals we're already
   logged in using some means.
2. Check the environment for a service principal as defined by the
   environment variables `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and
   `AZURE_CLIENT_SECRET`.
3. Check the `AZURE_CLIENT_ID` environment variable for the client ID of
   a user-assigned managed identity.
4. Use the system-assigned managed identity for the Azure resource if
   it's enabled.

- [x] Add documentation.
- [x] Use a good default command/flags for when mounting `.azure` directory.